### PR TITLE
Fixing "set_table_name" deprecation warnings

### DIFF
--- a/lib/acts_as_archive.rb
+++ b/lib/acts_as_archive.rb
@@ -133,7 +133,7 @@ class ActsAsArchive
           else
             eval <<-EVAL
               class ::#{options[:class]} < ActiveRecord::Base
-                table_name = "#{options[:table]}"
+                self.table_name = "#{options[:table]}"
               end
             EVAL
             klass = eval("::#{options[:class]}")

--- a/lib/acts_as_archive.rb
+++ b/lib/acts_as_archive.rb
@@ -129,11 +129,11 @@ class ActsAsArchive
           klass = eval(options[:class]) rescue nil
           
           if klass
-            klass.send :set_table_name, options[:table]
+            klass.send 'table_name=', options[:table]
           else
             eval <<-EVAL
               class ::#{options[:class]} < ActiveRecord::Base
-                set_table_name "#{options[:table]}"
+                table_name = "#{options[:table]}"
               end
             EVAL
             klass = eval("::#{options[:class]}")


### PR DESCRIPTION
Upgrading to rails 3.2 reveals a deprecation that is used heavily, and sprays out into our console profusely:

```
DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from acts_as_archive at /home/deploy/.rbenv/versions/1.9.3-p194/gemsets/accounts/bundler/gems/acts_as_archive-390fca44c084/lib/acts_as_archive.rb:132)
DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from <class:Archive> at (eval):2)
```

In my quick tests, these changes fix things. I made them in haste so some review might be in order.
